### PR TITLE
don`t  break libc internal functions: '_dl_catch_exception', '_dl_sig…

### DIFF
--- a/overthrower.cpp
+++ b/overthrower.cpp
@@ -554,6 +554,12 @@ static std::pair<bool, bool> checker(unsigned int depth, uintptr_t, uintptr_t, c
     if (depth == 3 && strstr(func_name, "ld-linux")) {
         return std::make_pair(false, true);
     }
+    if (depth == 5 && strstr(func_name, "_dl_catch_exception")) {
+        return std::make_pair(false, true);
+    }
+    if (depth == 2 && (strstr(func_name, "_dl_signal_error") || strstr(func_name, "_dl_exception_create") )) {
+        return std::make_pair(true, true);
+    }
     if ((depth == 4 || depth == 5) && strstr(func_name, "dlerror")) {
         return std::make_pair(false, true);
     }


### PR DESCRIPTION
don`t  break libc internal functions: '_dl_catch_exception', '_dl_signal_error' which can be called, and cause memory leak which is ok for libc usecase

```
 /lib64/ld-linux-x86-64.so.2 - _dl_signal_error + 0x71
 /lib64/ld-linux-x86-64.so.2 - _dl_open + 0x1bc
 /lib64/libdl.so.2 - dlopen_doit + 0x5b
 /lib64/ld-linux-x86-64.so.2 - _dl_catch_error + 0x64
 /lib64/libdl.so.2 - _dlerror_run + 0x6d
 /lib64/libdl.so.2 - dlopen + 0x31
                   - mclib_loadLibrary + 0x6a
                   - main + 0x16b
 /lib64/libc.so.6 - __libc_start_main + 0xf5
```

```
/lib64/ld-linux-x86-64.so.2 - _dl_signal_error + 0x71
/lib64/ld-linux-x86-64.so.2 - _dl_open + 0x1bc
/lib64/libdl.so.2 - dlopen_doit + 0x5b
/lib64/ld-linux-x86-64.so.2 - _dl_catch_error + 0x64
/lib64/libdl.so.2 - _dlerror_run + 0x6d
/lib64/libdl.so.2 - dlopen + 0x31
                  - mclib_loadLibrary + 0x6a
                  - main + 0x16b
/lib64/libc.so.6 - __libc_start_main + 0xf5
```